### PR TITLE
support pip "--find-links" argument for airgapped `pip_install()`

### DIFF
--- a/python/pip_install/extract_wheels/__init__.py
+++ b/python/pip_install/extract_wheels/__init__.py
@@ -59,6 +59,12 @@ def main() -> None:
         description="Resolve and fetch artifacts transitively from PyPI"
     )
     parser.add_argument(
+        "--find-links",
+        type=str,
+        default=None,
+        help="Directory to look for archives such as sdist or wheel files.",
+    )
+    parser.add_argument(
         "--requirements",
         action="store",
         required=True,
@@ -82,6 +88,7 @@ def main() -> None:
         + (["--isolated"] if args.isolated else [])
         + ["wheel", "-r", args.requirements]
         + ["--wheel-dir", os.getcwd()]
+        + (["--find-links", "{}/../{}".format(os.getcwd(), args.find_links)] if args.find_links else [])
         + deserialized_args["extra_pip_args"]
     )
 

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -160,6 +160,10 @@ def _pip_repository_impl(rctx):
             "--annotations",
             annotations_file,
         ]
+
+        # TODO: move this in to _parse_optional_attrs()
+        if rctx.attr.find_links:
+            args += ["--find-links", rctx.attr.find_links.workspace_name]
         progress_message = "Extracting wheels"
 
     args += ["--repo", rctx.attr.name, "--repo-prefix", rctx.attr.repo_prefix]
@@ -210,6 +214,12 @@ can be passed.
     ),
     "extra_pip_args": attr.string_list(
         doc = "Extra arguments to pass on to pip. Must not contain spaces.",
+    ),
+    "find_links": attr.label(
+        doc = """\
+The [--find-links](https://pip.pypa.io/en/stable/cli/pip_wheel/#cmdoption-f) to
+pass to the underlying pip command.
+""",
     ),
     "isolated": attr.bool(
         doc = """\


### PR DESCRIPTION
There was no way to provide a directory pertaining to the `--find-links` arg to pass to `pip` so this change adds such an attribute to the `pip_install` rule to support OpenTitan airgapped builds.

Signed-off-by: Timothy Trippel <ttrippel@google.com>

