### PR TITLE
Update pkginfo

### DIFF
--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -29,8 +29,8 @@ _RULE_DEPS = [
     ),
     (
         "pypi__pkginfo",
-        "https://files.pythonhosted.org/packages/cd/00/49f59cdd2c6a52e6665fda4de671dac5614366dc827e050c55428241b929/pkginfo-1.8.2-py2.py3-none-any.whl",
-        "c24c487c6a7f72c66e816ab1796b96ac6c3d14d49338293d2141664330b55ffc",
+        "https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl",
+        "c783ac885519cab2c34927ccfa6bf64b5a704d7c69afaea583dd9b7afe969343",
     ),
     (
         "pypi__setuptools",


### PR DESCRIPTION
This fixes a regression that causes an exception to be raised when building OT Python deps:

```
.../.cache/bazel/.../.../external/rules_python/python/pip_install/extract_wheels/lib/wheel.py", line 57, in entry_points
    name = "{}-{}".format(metadata.name.replace("-", "_"), metadata.version)
AttributeError: 'NoneType' object has no attribute 'replace'
```

The issue seems related to pkginfo not being able to parse newer versions of package metadata, although the reason why this started failing all of a sudden has not been root caused.

## To reproduce

In a fresh checkout of OpenTitan's `earlgrey_es_sival` branch (reproducing might require clearing your Bazel cache, but note that this will break future builds if this fix isn't applied):

```
$ bazel query "@ot_python_deps//:*"
...
 (Traceback (most recent call last):
  File "/home/noah/.cache/bazel/_bazel_noah/d7a503cb641b82d61262bab21b5880e3/external/python3_x86_64-unknown-linux-gnu/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/noah/.cache/bazel/_bazel_noah/d7a503cb641b82d61262bab21b5880e3/external/python3_x86_64-unknown-linux-gnu/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/noah/.cache/bazel/_bazel_noah/d7a503cb641b82d61262bab21b5880e3/external/rules_python/python/pip_install/extract_wheels/__main__.py", line 5, in <module>
    main()
  File "/home/noah/.cache/bazel/_bazel_noah/d7a503cb641b82d61262bab21b5880e3/external/rules_python/python/pip_install/extract_wheels/__init__.py", line 117, in main
    targets = [
  File "/home/noah/.cache/bazel/_bazel_noah/d7a503cb641b82d61262bab21b5880e3/external/rules_python/python/pip_install/extract_wheels/__init__.py", line 120, in <listcomp>
    bazel.extract_wheel(
  File "/home/noah/.cache/bazel/_bazel_noah/d7a503cb641b82d61262bab21b5880e3/external/rules_python/python/pip_install/extract_wheels/lib/bazel.py", line 412, in extract_wheel
    for name, entry_point in sorted(whl.entry_points().items()):
  File "/home/noah/.cache/bazel/_bazel_noah/d7a503cb641b82d61262bab21b5880e3/external/rules_python/python/pip_install/extract_wheels/lib/wheel.py", line 57, in entry_points
    name = "{}-{}".format(metadata.name.replace("-", "_"), metadata.version)
AttributeError: 'NoneType' object has no attribute 'replace'
)
```

Now, patch OpenTitan to apply this PR's changes:

```
diff --git a/WORKSPACE b/WORKSPACE
index 38da63b4c3..038d9cb8de 100644
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,14 @@

 workspace(name = "lowrisc_opentitan")

+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+     name = "rules_python",
+     remote = "https://github.com/nmoroze/rules_python.git",
+     commit = "f6e98e8e390198726dc8cdeedb8c1dbad7041020",
+)
+
 # Bazel skylib library
 load("//third_party/skylib:repos.bzl", "bazel_skylib_repos")
 bazel_skylib_repos()
```

The command now completes successfully when re-run:

```
$ bazel query "@ot_python_deps//:*"
Starting local Bazel server and connecting to it...
@ot_python_deps//:BUILD.bazel
@ot_python_deps//:requirements.bzl
Loading: 1 packages loaded 
```

Actually completing the fix will require updating OpenTitan to declare the newer version of rules_python early in `WORKSPACE` (as shown here), or threading it through other transitive dependencies (like crt). 